### PR TITLE
Updated to using newer poppler-simple

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "bluebird": "^2.9.13",
-    "poppler-simple": "^0.1.10"
+    "poppler-simple": "^0.2.1"
   }
 }


### PR DESCRIPTION
`poppler-simple` can now be built on Node.js 4.1.2. I hope this is helpful. Fixes #23. 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/lob/calipers/24)
<!-- Reviewable:end -->